### PR TITLE
Fix for opacity css rule

### DIFF
--- a/components/opening.vue
+++ b/components/opening.vue
@@ -74,7 +74,7 @@ export default {
         delay: 3000,
         translateY: 375,
         duration: 3300,
-        opacioty: 100,
+        opacity: 1, // Opacity values goes from 0 to 1
       },
       scale: [
         { value: 0.1, easing: "easeOutSine", duration: 500 },


### PR DESCRIPTION
Habia una regla que decia "opacioty" y es "opacity" y los valores van de 0 a 1 (si es que sigue la logica de CSS)